### PR TITLE
thorium-chromium: update livecheck

### DIFF
--- a/Casks/thorium-chromium.rb
+++ b/Casks/thorium-chromium.rb
@@ -13,10 +13,14 @@ cask "thorium-chromium" do
 
   livecheck do
     url "https://api.github.com/repos/Alex313031/Thorium-Special/releases"
-    regex(/.*MacOS.*/i)
+    regex(%r{/([^/]+?)/Thorium[._-]MacOS[._-]#{arch}\.dmg}i)
     strategy :json do |json, regex|
-      json["versions"].select { |item| item["name"]&.match?(regex) }
-                      .map { |item| item["tag_name"] }
+      json.map do |release|
+        asset = release["assets"]&.find { |asset| asset["browser_download_url"]&.match(regex) }
+        next if asset.blank?
+
+        asset["browser_download_url"][regex, 1]
+      end
     end
   end
 


### PR DESCRIPTION
As described in the [related discussion topic](https://github.com/orgs/Homebrew/discussions/4299#discussioncomment-5207708), the `releases` response takes the form of an array of release objects, where you have to iterate over each and check their `assets` array for a `browser_download_url` string with a matching dmg file. This PR updates the `strategy` block to implement this approach along with a regex that extracts the version from the tag in the dmg URL string.

The related brew fix is now merged (https://github.com/Homebrew/brew/pull/14890), so this should work as expected (though you may need to run `brew update` first to get the fix):

```
$ brew livecheck --debug thorium-chromium

Cask:             thorium-chromium
Livecheckable?:   Yes

URL:              https://api.github.com/repos/Alex313031/Thorium-Special/releases
Strategy:         Json
Regex:            /\/([^\/]+?)\/Thorium[._-]MacOS[._-]arm64\.dmg/i

Matched Versions:
M109.0.5414.120-2, M109.0.5361.0, M105.0.5127.0, M104.0.5079.0, M103.0.5037.0-1, M103.0.5020.0-1

thorium-chromium: M109.0.5414.120-2 ==> M109.0.5414.120-2
```